### PR TITLE
feat: trigger recognition on photo keyword

### DIFF
--- a/19OK.py
+++ b/19OK.py
@@ -462,19 +462,21 @@ class MainWindow(QtWidgets.QWidget):
             print("[协议] 非法 JSON:", e)
             return
 
-        tp = cmd.get("reqType")
         cam = int(cmd.get("camID", 0))
 
-        if tp == "photo":
+        if "photo" in text:
             self.do_capture_and_send(cam)
-            ack = {
+            reply = {
                 "dsID": "www.hc-system.com.cam",
                 "reqType": "photo",
-                "camID": cam,
+                "camID": 0,
                 "ret": 1,
             }
-            self._send_json(ack)
-        elif tp == "listModel":
+            self._send_json(reply)
+            return
+
+        tp = cmd.get("reqType")
+        if tp == "listModel":
             self._send_json(self.build_model_list_reply())
         elif tp == "changeModel":
             self.current_model = (cmd["name"], cmd["model"])


### PR DESCRIPTION
## Summary
- trigger recognition when incoming messages contain `photo`
- send standard response with `dsID` `www.hc-system.com.cam`, `reqType` `photo`, `camID` 0 and `ret=1`

## Testing
- `python -m py_compile 19OK.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0a70744083299fb7d918ce657605