### PR TITLE
feat: trigger recognition via photo command

### DIFF
--- a/19OK.py
+++ b/19OK.py
@@ -423,13 +423,13 @@ class MainWindow(QtWidgets.QWidget):
     def do_capture_and_send(self, cam_id: int):
         if not self.capture or not self.capture.isOpened():
             print("[摄像头] 未就绪")
-            return
+            return []
         if cam_id != self.cam_combo.currentData():
             print(f"[警告] 请求的相机 {cam_id} 与当前选择的不一致")
         ok, frame = self.capture.read()
         if not ok or frame is None or frame.size == 0:
             print("[摄像头] 读取失败")
-            return
+            return []
 
         shapes_enabled = {
             s for s, chk in [
@@ -441,9 +441,11 @@ class MainWindow(QtWidgets.QWidget):
         }
         labels = detect_shapes(frame, list(self.colors.values()), shapes_enabled)
 
+        results = []
         if not labels:
             print("[识别] 未检测到目标")
         for text, _pos, _col in labels:
+            results.append(text)
             if text in self.cmd_map:
                 msg = self.cmd_map[text]
                 if self.tcp_sender:
@@ -454,6 +456,8 @@ class MainWindow(QtWidgets.QWidget):
             else:
                 print(f"[未配置] {text}")
 
+        return results
+
     def handle_hc_cmd(self, text: str):
         self.append_log(f"[指令] {text}")
         try:
@@ -462,19 +466,24 @@ class MainWindow(QtWidgets.QWidget):
             print("[协议] 非法 JSON:", e)
             return
 
-        tp = cmd.get("reqType")
         cam = int(cmd.get("camID", 0))
 
-        if tp == "photo":
-            self.do_capture_and_send(cam)
-            ack = {
-                "dsID": "www.hc-system.com.cam",
-                "reqType": "photo",
-                "camID": cam,
-                "ret": 1,
-            }
-            self._send_json(ack)
-        elif tp == "listModel":
+        if cmd.get("reqType") == "photo":
+            # 在 GUI 线程中模拟按下识别按钮，并回传固定报文
+            def task():
+                self.recognize_btn.click()
+                reply = {
+                    "dsID": "www.hc-system.com.cam",
+                    "reqType": "photo",
+                    "camID": cam,
+                    "ret": 1,
+                }
+                self._send_json(reply)
+            QtCore.QTimer.singleShot(0, task)
+            return
+
+        tp = cmd.get("reqType")
+        if tp == "listModel":
             self._send_json(self.build_model_list_reply())
         elif tp == "changeModel":
             self.current_model = (cmd["name"], cmd["model"])


### PR DESCRIPTION
## Summary
- Run the same recognition routine as the GUI button when a `photo` message is received
- Reply with a fixed JSON acknowledgement containing `dsID`, `reqType`, `camID` and `ret: 1`

## Testing
- `python -m py_compile 19OK.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0a70744083299fb7d918ce657605